### PR TITLE
Clean up dependencies with api/implementation separation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,27 +1,9 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile project(":core")
-    compile 'io.rsocket:rsocket-android-core:0.9-SNAPSHOT'
-    compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.1.8'
+    api project(":core")
+    api 'io.rsocket:rsocket-android-core'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7'
 
-    testCompile project(":codec-jackson")
-    testCompile 'io.rsocket:rsocket-transport-okhttp:0.9-SNAPSHOT'
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
+    testImplementation project(":codec-jackson")
+    testImplementation 'io.rsocket:rsocket-transport-okhttp'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,71 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "io.spring.gradle:dependency-management-plugin:1.0.5.RELEASE"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.31"
+    }
+}
+
+configure(subprojects.findAll { it.name != 'java' }) {
+
+    apply plugin: 'kotlin'
+
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.6"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.6"
+    }
+}
+
 subprojects {
 
     group = 'com.github.mostroverkhov.r2'
     version = mavenversion
 
-    apply plugin: 'java'
+    buildscript {
+        repositories {
+            mavenCentral()
+        }
+    }
+
+    apply plugin: 'java-library'
+    apply plugin: 'io.spring.dependency-management'
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'jacoco'
+
 
     repositories {
         mavenCentral()
         maven { url 'https://oss.jfrog.org/libs-snapshot' }
     }
 
-    ext {
-        kotlin_version = '1.2.31'
+    dependencyManagement {
+        dependencies {
+            dependency "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.31"
+            dependency group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.2'
+
+            dependencySet(group: 'io.projectreactor', version: '3.1.2.RELEASE') {
+                entry 'reactor-core'
+                entry 'reactor-test'
+            }
+            dependency 'io.rsocket:rsocket-core:0.9.16'
+            dependency 'io.rsocket:rsocket-transport-netty:0.9.16'
+
+            dependency 'io.rsocket:rsocket-android-core:0.9-SNAPSHOT'
+            dependency 'io.rsocket:rsocket-transport-okhttp:0.9-SNAPSHOT'
+
+            dependency 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
+            dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.9.5') {
+                entry 'jackson-dataformat-smile'
+                entry 'jackson-dataformat-cbor'
+            }
+        }
     }
 
     dependencies {

--- a/codec-jackson-binary/build.gradle
+++ b/codec-jackson-binary/build.gradle
@@ -1,26 +1,9 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin'
 
 dependencies {
-    compile project(":codec-jackson")
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-smile', version: '2.9.5'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.9.5'
+    api project(":codec-jackson")
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7'
 
-    testCompile project(':codec-jackson').sourceSets.test.output
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
+    testImplementation project(':codec-jackson').sourceSets.test.output
 }

--- a/codec-jackson/build.gradle
+++ b/codec-jackson/build.gradle
@@ -1,23 +1,6 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin'
 
 dependencies {
-    compile project(":core")
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.5'
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
+    api project(":core")
+    api 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7'
 }

--- a/codec-proto/build.gradle
+++ b/codec-proto/build.gradle
@@ -1,22 +1,20 @@
 buildscript {
-    repositories {
-        mavenCentral()
-    }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
     }
-
-
 }
 
-apply plugin: 'kotlin'
 apply plugin: 'com.google.protobuf'
 
+ext {
+    protoc_version = '3.5.0'
+    protoc_lite_version = '3.0.0'
+}
+
 dependencies {
-    testCompile 'com.google.protobuf:protobuf-lite:3.0.0'
-    compileOnly 'com.google.protobuf:protobuf-lite:3.0.0'
-    compile project(":core")
+    api project(":core")
+    api "com.google.protobuf:protobuf-lite:$protoc_lite_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
 }
 
 sourceSets {
@@ -30,13 +28,13 @@ sourceSets {
 protobuf {
 
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.0'
+        artifact = "com.google.protobuf:protoc:$protoc_version"
     }
 
     plugins {
         javalite {
             // The codegen for lite comes as a separate artifact
-            artifact = 'com.google.protobuf:protoc-gen-javalite:3.0.0'
+            artifact = "com.google.protobuf:protoc-gen-javalite:$protoc_lite_version"
         }
     }
 
@@ -56,11 +54,4 @@ protobuf {
             }
         }
     }
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,26 +1,6 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin'
-
-repositories {
-    mavenCentral()
-}
+sourceCompatibility = 1.6
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.2'
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
+    implementation 'org.reactivestreams:reactive-streams'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 mavenversion=0.1-SNAPSHOT
+org.gradle.parallel=true
+org.gradle.configureondemand=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -3,11 +3,12 @@ apply plugin: 'java'
 sourceCompatibility = 1.8
 
 dependencies {
-    compile project(":core")
-    compile 'io.rsocket:rsocket-core:0.9.16'
-    compile group: 'io.projectreactor', name: 'reactor-core', version: '3.1.2.RELEASE'
+    api project(":core")
+    api 'io.rsocket:rsocket-core'
+    api 'io.projectreactor:reactor-core'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
 
-    testCompile project(":codec-jackson")
-    testCompile 'io.rsocket:rsocket-transport-netty:0.9.16'
-    testCompile group: 'io.projectreactor', name: 'reactor-test', version: '3.1.2.RELEASE'
+    testImplementation project(":codec-jackson")
+    testImplementation 'io.rsocket:rsocket-transport-netty'
+    testImplementation 'io.projectreactor:reactor-test'
 }


### PR DESCRIPTION
Fix issue with Core module target compatibility set to java8. Use java6 source/target compat instead

Trim exported compile dependencies

Update gradle wrapper version, enable parallel execution & configure-on-demand

Introduce dependency-management-plugin
