### PR TITLE
Separate module for examples

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'java'
+
+dependencies {
+    implementation project(":reactor-java")
+    implementation project(":codec-jackson")
+    implementation 'io.rsocket:rsocket-transport-netty'
+}
+

--- a/example/src/main/java/com/github/mostroverkhov/r2/example/JavaClientServerExample.java
+++ b/example/src/main/java/com/github/mostroverkhov/r2/example/JavaClientServerExample.java
@@ -1,11 +1,18 @@
-package com.github.mostroverkhov.r2.java;
+package com.github.mostroverkhov.r2.example;
 
 import com.github.mostroverkhov.r2.codec.jackson.JacksonJsonDataCodec;
+import com.github.mostroverkhov.r2.core.Codecs;
 import com.github.mostroverkhov.r2.core.Metadata;
 import com.github.mostroverkhov.r2.core.RequesterFactory;
-import com.github.mostroverkhov.r2.core.Codecs;
 import com.github.mostroverkhov.r2.core.Services;
-import com.github.mostroverkhov.r2.java.JavaMocks.Person;
+import com.github.mostroverkhov.r2.example.Contract.Person;
+import com.github.mostroverkhov.r2.example.Contract.PersonServiceHandler;
+import com.github.mostroverkhov.r2.example.Contract.PersonsService;
+import com.github.mostroverkhov.r2.example.Contract.RequestingPersonServiceHandler;
+import com.github.mostroverkhov.r2.java.ClientAcceptorBuilder;
+import com.github.mostroverkhov.r2.java.R2Client;
+import com.github.mostroverkhov.r2.java.R2Server;
+import com.github.mostroverkhov.r2.java.ServerAcceptorBuilder;
 import io.rsocket.RSocketFactory;
 import io.rsocket.transport.netty.client.TcpClientTransport;
 import io.rsocket.transport.netty.server.NettyContextCloseable;
@@ -17,8 +24,6 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 
-import static com.github.mostroverkhov.r2.java.JavaMocks.*;
-import static com.github.mostroverkhov.r2.java.JavaMocks.PersonsService;
 
 public class JavaClientServerExample {
 
@@ -86,7 +91,8 @@ public class JavaClientServerExample {
   private static ClientAcceptorBuilder configureClient(
       ClientAcceptorBuilder b) {
     return b
-        .codecs(new Codecs().add(new JacksonJsonDataCodec()))
+        .codecs(new Codecs()
+            .add(new JacksonJsonDataCodec()))
         .services(requesterFactory ->
             new Services()
                 .add(new PersonServiceHandler("client")));

--- a/reactor-java/build.gradle
+++ b/reactor-java/build.gradle
@@ -8,6 +8,5 @@ dependencies {
     api 'io.projectreactor:reactor-core'
 
     testImplementation project(":codec-jackson")
-    testImplementation 'io.rsocket:rsocket-transport-netty'
     testImplementation 'io.projectreactor:reactor-test'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,5 @@ include 'codec-jackson'
 include 'codec-jackson-binary'
 include 'codec-proto'
 include 'contract'
+include 'example'
 


### PR DESCRIPTION
Separate module for examples. This change helps spot problems when some types are available only on runtime classpath, and not compile classpath